### PR TITLE
Lyrics download fixes

### DIFF
--- a/src/core/metadata/thb-wiki/lyrics/lyric-parser.ts
+++ b/src/core/metadata/thb-wiki/lyrics/lyric-parser.ts
@@ -73,7 +73,7 @@ class OriginalLyricParser extends LyricParser {
     return originalData.textContent
   }
   getLrcFileSuffix(): string {
-    return ''
+    return '.'
   }
 }
 class TranslatedLyricParser extends LyricParser {

--- a/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
+++ b/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
@@ -44,7 +44,17 @@ export const downloadLyrics = async (
   log(`\n下载歌词中: ${title}`)
   let document = lyricDocumentCache.find(it => it.url === url)?.document
   if (!document) {
-    const response = await axios.get(url, { timeout: config.timeout * 1000 })
+    log(url)
+    let response: AxiosResponse<string>
+    try {
+      response = await axios.get(url, { timeout: config.timeout * 1000 })
+    } catch (error) {
+      console.error(`下载歌词页面失败: ${url}`)
+      return {
+        lyric: '',
+        lyricLanguage: undefined,
+      }
+    }
     document = parseHTML(response.data).window.document
     lyricDocumentCache.push({ url, document })
     if (lyricDocumentCache.length > config.lyric.maxCacheSize) {

--- a/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
+++ b/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
@@ -16,16 +16,17 @@ const downloadMetadataLyrics = async () => {
   }
 }
 const downloadLrcLyrics = async (title: string, index: number, config: MetadataConfig) => {
-  const language = lyricParser.findLanguage()
+  const lyricLanguage = lyricParser.findLanguage()
+  const languageSuffix = lyricParser.getLrcFileSuffix()
   const indexString = index === 0 ? '' : `.${index + 1}`
-  const url = `https://touhou.cd/lyrics/${encodeURIComponent(title)}${indexString}${language}.lrc`
+  const url = `https://touhou.cd/lyrics/${encodeURIComponent(title)}${indexString}${languageSuffix}.lrc`
   log(url)
   let response: AxiosResponse<string>
   try {
     response = await axios.get(url, { responseType: 'text', timeout: config.timeout * 1000 })
     return {
       lyric: response.data,
-      lyricLanguage: undefined,
+      lyricLanguage: lyricLanguage,
     }
   } catch (error) {
     console.error(`下载歌词失败: ${url}`)

--- a/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
+++ b/src/core/metadata/thb-wiki/lyrics/thb-wiki-lyrics.ts
@@ -19,7 +19,7 @@ const downloadLrcLyrics = async (title: string, index: number, config: MetadataC
   const lyricLanguage = lyricParser.findLanguage()
   const languageSuffix = lyricParser.getLrcFileSuffix()
   const indexString = index === 0 ? '' : `.${index + 1}`
-  const url = `https://touhou.cd/lyrics/${encodeURIComponent(title)}${indexString}${languageSuffix}.lrc`
+  const url = `https://cd.thwiki.cc/lyrics/${encodeURIComponent(title)}${indexString}${languageSuffix}.lrc`
   log(url)
   let response: AxiosResponse<string>
   try {


### PR DESCRIPTION
This PR mainly fixes some errors when doing lyrics downloads

In "Metadata" mode:
- Handle request errors when failed to retrieve lyrics page

In "LRC" mode
- Uses the correct url suffixes for LRC lyrics download
- Change the LRC lyrics host from touhou.cd => cd.thwiki.cc (As stated in touhou.cd, it would be not maintained soon)